### PR TITLE
fix: 로그인 시 세션에 dto를 넘기도록 수정 / 세션리스트 확인할 수 있도록 함

### DIFF
--- a/src/main/java/likelion15/mutsa/controller/JoinController.java
+++ b/src/main/java/likelion15/mutsa/controller/JoinController.java
@@ -55,7 +55,7 @@ public class JoinController {
 
         User user = joinService.joinUser(joinDto);
 
-        System.out.println("user = " + user);
+       log.info(user.toString());
 
         re.addAttribute("realName", joinDto.getRealName());
         return "redirect:/complete-join";

--- a/src/main/java/likelion15/mutsa/controller/JoinController.java
+++ b/src/main/java/likelion15/mutsa/controller/JoinController.java
@@ -43,7 +43,7 @@ public class JoinController {
 
     @PostMapping("/join")
     public String completeJoin(JoinDto joinDto,
-                               RedirectAttributes re, Model model) {
+                               RedirectAttributes re) {
 
         if (joinService.IsExistEmail(joinDto.getEmail())) {
             re.addFlashAttribute("error","이미 가입된 이메일입니다.");

--- a/src/main/java/likelion15/mutsa/controller/LoginController.java
+++ b/src/main/java/likelion15/mutsa/controller/LoginController.java
@@ -78,8 +78,7 @@ public class LoginController {
     }
     @GetMapping("/home")
     public String home(Model model,
-                       @SessionAttribute(name="sessionDto",required = false) SessionDto sessionDto,
-                       HttpServletRequest httpServletRequest){
+                       @SessionAttribute(name="sessionDto",required = false) SessionDto sessionDto){
 
         if ((sessionDto != null)) {
             model.addAttribute("name", sessionDto.getName());

--- a/src/main/java/likelion15/mutsa/controller/LoginController.java
+++ b/src/main/java/likelion15/mutsa/controller/LoginController.java
@@ -29,7 +29,7 @@ public class LoginController {
     private final JoinService joinService;
 
     // 세션리스트 확인용
-    private static Hashtable sessionList = new Hashtable();
+    private final static Hashtable sessionList = new Hashtable();
 
     // 로그인 페이지
     @GetMapping("/login")

--- a/src/main/java/likelion15/mutsa/controller/LoginController.java
+++ b/src/main/java/likelion15/mutsa/controller/LoginController.java
@@ -11,11 +11,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.SessionAttribute;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
@@ -25,6 +27,9 @@ public class LoginController {
 
     private final LoginService loginService;
     private final JoinService joinService;
+
+    // 세션리스트 확인용
+    private static Hashtable sessionList = new Hashtable();
 
     // 로그인 페이지
     @GetMapping("/login")
@@ -51,8 +56,13 @@ public class LoginController {
             SessionDto sessionDto = loginService.createSessionDto(user);
 
             // 세션에 sessionDto를 넣어줌
-            session.setAttribute("sessionDto", sessionDto);
+            session.setAttribute("uuid", sessionDto);
             session.setMaxInactiveInterval(1800); // 1800=30분
+
+            // 세션을 세션리스트에 추가(세션 리스트 확인용)
+            // getid가 아니고 uuid 추가해야하는지 알아보고 수정하기[ ]
+            sessionList.put(session.getId(), session);
+
             return "redirect:/home";
         } else { // 로그인 실패
             if(!joinService.IsExistEmail(joinDto.getEmail())){
@@ -70,6 +80,9 @@ public class LoginController {
         //세션이 없으면 null return
         HttpSession session = request.getSession(false);
         if (session != null) {
+            // 로그아웃 시 세션 리스트에서도 제거
+            sessionList.remove(session.getId());
+
             session.invalidate();
         }
 
@@ -77,12 +90,31 @@ public class LoginController {
     }
     @GetMapping("/home")
     public String home(Model model,
-                       @SessionAttribute(name="sessionDto",required = false) SessionDto sessionDto){
+                       @SessionAttribute(name="uuid",required = false) SessionDto sessionDto){
 
         if ((sessionDto != null)) {
             model.addAttribute("name", sessionDto.getName());
         }
 
         return "home";
+    }
+    // 세션 리스트 확인용
+    // {세션id : uuid, 세션id, uuid,..} 형태로 로그인한 유저확인
+    @GetMapping("/session-list")
+    @ResponseBody
+    public Map<String,String> sessionList(){
+        Enumeration elements = sessionList.elements();
+        Map<String,String> lists = new HashMap<>();
+        while (elements.hasMoreElements()) {
+
+            HttpSession session = (HttpSession) elements.nextElement();
+
+            try{
+                lists.put(session.getId(), ((SessionDto) session.getAttribute("uuid")).getUuid());
+            }catch (IllegalStateException e){
+                // 세션이 이미 무효화된 경우, 해당 세션은 무시하고 다음 세션으로 진행
+            }
+        }
+        return lists;
     }
 }

--- a/src/main/java/likelion15/mutsa/controller/LoginController.java
+++ b/src/main/java/likelion15/mutsa/controller/LoginController.java
@@ -3,6 +3,7 @@ package likelion15.mutsa.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import likelion15.mutsa.dto.JoinDto;
+import likelion15.mutsa.dto.SessionDto;
 import likelion15.mutsa.entity.User;
 import likelion15.mutsa.service.JoinService;
 import likelion15.mutsa.service.LoginService;
@@ -46,8 +47,12 @@ public class LoginController {
             httpServletRequest.getSession().invalidate();
             HttpSession session = httpServletRequest.getSession(true);
 
-            // 세션에 userId를 넣어줌
-            session.setAttribute("userId", userId);
+            // sessionDto
+            User user = loginService.getLoginUser(userId);
+            SessionDto sessionDto = loginService.createSessionDto(user);
+
+            // 세션에 sessionDto를 넣어줌
+            session.setAttribute("sessionDto", sessionDto);
             session.setMaxInactiveInterval(1800); // 1800=30분
             return "redirect:/home";
         } else { // 로그인 실패
@@ -73,19 +78,11 @@ public class LoginController {
     }
     @GetMapping("/home")
     public String home(Model model,
-                       @SessionAttribute(name="userId",required = false) Long userId,
+                       @SessionAttribute(name="sessionDto",required = false) SessionDto sessionDto,
                        HttpServletRequest httpServletRequest){
 
-        if(userId == null)
-            System.out.println("로그인 하지 않음");
-        else{
-            User loginUser = loginService.getLoginUser(userId);
-            // 84-86줄 추가하긴 하였는데 확신X
-            if(loginUser == null){
-                httpServletRequest.getSession().invalidate();
-            }
-            System.out.println("로그인 유저의 Id:"+userId);
-            model.addAttribute("name", loginUser.getName());
+        if ((sessionDto != null)) {
+            model.addAttribute("name", sessionDto.getName());
         }
 
         return "home";

--- a/src/main/java/likelion15/mutsa/controller/LoginController.java
+++ b/src/main/java/likelion15/mutsa/controller/LoginController.java
@@ -9,7 +9,6 @@ import likelion15.mutsa.service.JoinService;
 import likelion15.mutsa.service.LoginService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.Banner;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/likelion15/mutsa/dto/SessionDto.java
+++ b/src/main/java/likelion15/mutsa/dto/SessionDto.java
@@ -1,0 +1,23 @@
+package likelion15.mutsa.dto;
+
+import likelion15.mutsa.entity.enums.UserAuth;
+import likelion15.mutsa.entity.enums.UserStatus;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+
+public class SessionDto {
+    private String uuid;
+    private String name;
+    private String email;
+    private String realName;
+    private String phoneNumber;
+    private String password;
+    private UserAuth auth;
+    private UserStatus status;
+}

--- a/src/main/java/likelion15/mutsa/service/LoginService.java
+++ b/src/main/java/likelion15/mutsa/service/LoginService.java
@@ -1,12 +1,17 @@
 package likelion15.mutsa.service;
 
+import likelion15.mutsa.dto.SessionDto;
+import likelion15.mutsa.entity.Profile;
 import likelion15.mutsa.entity.User;
+import likelion15.mutsa.entity.enums.UserAuth;
+import likelion15.mutsa.entity.enums.UserStatus;
 import likelion15.mutsa.repository.UserRepos;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -17,7 +22,7 @@ public class LoginService {
     // 로그인 검사
     public Long login(String email, String password) {
         User user = repository.findByEmail(email);
-
+    // Optional로 감싸서 받고 에러 처리 따로(not found 에러에 대한 advice만들어서 공통된 메시지를 보내준다거나 )
         if (user== null){ // 아이디가 존재하지 않는 경우
             return null;
         }
@@ -35,6 +40,23 @@ public class LoginService {
         }else{
             return null;
         }
+    }
 
+    public SessionDto createSessionDto(User user) {
+
+        UUID uuid = UUID.randomUUID();
+
+        SessionDto sessionDto = SessionDto.builder()
+                .uuid(uuid.toString())
+                .name(user.getName())
+                .realName(user.getRealName())
+                .email(user.getEmail())
+                .password(user.getPassword())
+                .phoneNumber(user.getPhoneNumber())
+                .auth(UserAuth.USER)
+                .status(UserStatus.U)
+                .build();
+        // 프로필은 제외했음.
+        return sessionDto;
     }
 }

--- a/src/main/java/likelion15/mutsa/service/LoginService.java
+++ b/src/main/java/likelion15/mutsa/service/LoginService.java
@@ -1,6 +1,9 @@
 package likelion15.mutsa.service;
 
+import likelion15.mutsa.dto.SessionDto;
 import likelion15.mutsa.entity.User;
+import likelion15.mutsa.entity.enums.UserAuth;
+import likelion15.mutsa.entity.enums.UserStatus;
 import likelion15.mutsa.repository.UserRepos;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +21,6 @@ public class LoginService {
     // 로그인 검사
     public Long login(String email, String password) {
         User user = repository.findByEmail(email);
-    // Optional로 감싸서 받고 에러 처리 따로(not found 에러에 대한 advice만들어서 공통된 메시지를 보내준다거나 )
         if (user== null){ // 아이디가 존재하지 않는 경우
             return null;
         }


### PR DESCRIPTION

![image](https://github.com/LikeLion15/Techit_Community/assets/127908945/2e2e6ff2-dfdc-480e-afd0-8ae5f78b7b88)

1. 로그인하면 세션 정보 DTO로 넘기도록 변경하였습니다.
->uuid와 User의 정보들 모두 포함하는(name,email...) 별도의 SessionDto를 만들어 세션에 넘기도록 하였습니다.
SessionDto이나 이름은 uuid로 설정하였습니다.

다른 곳에서 활용할 떄  home에서 @SessionAttribute이용해서 가져오는 것보고 참고해서 dto사용하시면 될 것 같습니다.




![image](https://github.com/LikeLion15/Techit_Community/assets/127908945/7861e535-3b89-4f53-a6b0-92415543d7a0)

2. 세션 리스트 
로그인을 하게 되면 /session-list 에서 로그인 유저의 uuid정보를 확인할 수 있습니다. 로그아웃 시 보이지 않음

미진행 :  로그인 서비스 로직을 바꿔야하는 부분, 백에서 에러처리
